### PR TITLE
refactor BrodEx.Client to be an actual supervisable client

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export KAFKA_HOST=127.0.0.1
+

--- a/dev/kafka.yml
+++ b/dev/kafka.yml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:1.1.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_HOST}
+      KAFKA_CREATE_TOPICS: "test.topic:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181/kafka
+      KAFKA_DELETE_TOPICS_ENABLE: "true"
+      # 10 MB
+      KAFKA_MESSAGE_MAX_BYTES: "10000000"
+      KAFKA_MAX_MESSAGE_BYTES: "10000000"
+      KAFKA_REPLICA_FETCH_MAX_BYTES: "10000000"
+      KAFKA_SOCKET_REQUEST_MAX_BYTES: "104857600"
+      KAFKA_LOG_RETENTION_HOURS: "1"
+      # 5 GB
+      KAFKA_LOG_RETENTION_BYTES: "5000000000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-manager:
+    image: solsson/kafka-manager
+    depends_on:
+      - zookeeper
+      - kafka
+    ports:
+      - "8080:8080"
+    environment:
+      ZK_HOSTS: zookeeper:2181/kafka
+    command:
+    - -Dhttp.port=8080
+
+

--- a/example/.formatter.exs
+++ b/example/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+example-*.tar
+

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,21 @@
+# Example
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `example` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:example, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/example](https://hexdocs.pm/example).
+

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :sasl, :sasl_error_logger, false
+
+config :example, Example.BrodClient, endpoints: ["localhost:9092"]
+

--- a/example/lib/example.ex
+++ b/example/lib/example.ex
@@ -1,0 +1,14 @@
+defmodule Example do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      Example.BrodClient
+    ]
+
+    opts = [strategy: :one_for_one, name: Example.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+end
+

--- a/example/lib/example/brod_client.ex
+++ b/example/lib/example/brod_client.ex
@@ -1,0 +1,4 @@
+defmodule Example.BrodClient do
+  use BrodEx, otp_app: :example
+end
+

--- a/example/lib/mix/tasks/observer.ex
+++ b/example/lib/mix/tasks/observer.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Observer do
+  def run(_) do
+    Application.ensure_all_started(:example)
+    :observer.start()
+    Process.sleep(:infinity)
+  end
+end

--- a/example/mix.exs
+++ b/example/mix.exs
@@ -14,7 +14,7 @@ defmodule Example.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: []
+      mod: {Example, []}
     ]
   end
 

--- a/example/mix.exs
+++ b/example/mix.exs
@@ -1,0 +1,27 @@
+defmodule Example.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example,
+      version: "0.1.0",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: []
+    ]
+  end
+
+  defp deps do
+    [
+      {:brod_ex, path: "../"}
+    ]
+  end
+end
+

--- a/example/mix.lock
+++ b/example/mix.lock
@@ -1,10 +1,5 @@
 %{
   "brod": {:hex, :brod, "3.0.0", "b3acc83fcb9a9d23e3dd662766953a42c0f903723b943474eaadf45e6b31026a", [:make, :rebar, :rebar3], [{:kafka_protocol, "1.0.0", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "kafka_protocol": {:hex, :kafka_protocol, "1.0.0", "f1eeef628f3f233ad9b8cc0134db21ce81e24f3104fa8be215da9caaffd1772f", [:rebar, :rebar3], [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
   "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm"},
   "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], [], "hexpm"},

--- a/example/test/example_test.exs
+++ b/example/test/example_test.exs
@@ -1,0 +1,18 @@
+defmodule ExampleTest do
+  use ExUnit.Case
+  doctest Example
+
+  alias Example.BrodClient
+
+  test "brod_ex is started with the example application" do
+    apps = Application.started_applications
+    assert List.keyfind(apps, :example, 0) != nil
+    assert List.keyfind(apps, :brod_ex, 0) != nil
+  end
+
+  test "produce a message to kafka" do
+    assert :ok = BrodClient.produce_sync("test.topic", 0, "key", "value")
+  end
+
+end
+

--- a/example/test/test_helper.exs
+++ b/example/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/brod_ex/client.ex
+++ b/lib/brod_ex/client.ex
@@ -1,33 +1,37 @@
 defmodule BrodEx.Client do
   @moduledoc false
 
-  defmacro __using__(opts \\ []) do
-    quote bind_quoted: [opts: opts] do
-      otp_app = Keyword.fetch!(opts, :otp_app)
-
-      @otp_app otp_app
-
-      @default_brod_client :default_brod_client
+  defmacro __using__(module_opts \\ []) do
+    quote bind_quoted: [module_opts: module_opts] do
+      @otp_app Keyword.fetch!(module_opts, :otp_app)
 
       alias BrodEx.Config
-      alias Brodex.KafkaMessage
-
-      @type endpoint :: String.t
-      @type endpoints :: [endpoint] | String.t
 
       def start_link(opts \\ []) do
-        config  = Application.get_env(@otp_app, __MODULE__, [])
-        Config.build_config(config)
-        :brod.start(:normal, nil)
+        client_config = Application.get_env(@otp_app, __MODULE__, [])
+                        |> Keyword.merge(opts)
+                        |> Config.brod_client_config()
+        clients = Application.get_env(:brod, :clients, [])
+                  |> Keyword.merge([{__MODULE__, client_config}])
+
+        Application.put_env(:brod, :clients, clients)
+
+        :brod.start_link_client(client_config[:endpoints], __MODULE__, client_config)
       end
 
       def child_spec(opts) do
         %{
           id: __MODULE__,
           start: {__MODULE__, :start_link, [opts]},
-          type: :supervisor
+          type: :worker
         }
       end
+
+      def produce_sync(topic, partition, key, value) do
+        BrodEx.produce_sync(__MODULE__, topic, partition, key, value)
+      end
+
     end
   end
+
 end

--- a/lib/brod_ex/client.ex
+++ b/lib/brod_ex/client.ex
@@ -1,16 +1,37 @@
 defmodule BrodEx.Client do
-  @moduledoc false
+  @moduledoc """
+  Defines a client to interact with a Kafka cluster.
 
-  defmacro __using__(module_opts \\ []) do
-    quote bind_quoted: [module_opts: module_opts] do
-      @otp_app Keyword.fetch!(module_opts, :otp_app)
+  Similar to an Ecto Repo, you define your own module and configure connection
+  and client behaviour in your `config/config.exs.`
 
-      alias BrodEx.Config
+  When used the client expects the `:otp_app` as option. The `:otp_app` should point
+  to an OTP application that has the Kafka client configuration. For example, the client:
+
+      defmodule MyApp.Kafka do
+        use BrodEx.Client, otp_app: :my_app
+      end
+
+  Can be configured with:
+
+      config :your_app, YourApp.Kafka,
+        endpoints: "localhost:9092"
+
+  The client will transparently handle re-connection to your Kafka cluster.
+  """
+
+  @type t :: module
+
+  @doc false
+  defmacro __using__(use_opts \\ []) do
+    quote bind_quoted: [use_opts: use_opts] do
+      @behaviour BrodEx.Client
+      @otp_app Keyword.fetch!(use_opts, :otp_app)
 
       def start_link(opts \\ []) do
         client_config = Application.get_env(@otp_app, __MODULE__, [])
                         |> Keyword.merge(opts)
-                        |> Config.brod_client_config()
+                        |> BrodEx.Config.brod_client_config()
         clients = Application.get_env(:brod, :clients, [])
                   |> Keyword.merge([{__MODULE__, client_config}])
 
@@ -31,7 +52,24 @@ defmodule BrodEx.Client do
         BrodEx.produce_sync(__MODULE__, topic, partition, key, value)
       end
 
+      defoverridable child_spec: 1
     end
   end
 
+  @doc """
+  Starts a `:brod_client` and returns `{:ok, pid}`.
+
+  ## Options
+
+    * `:endpoints` – The `host:port` string(s) of the Kafka broker to connect to.
+      Can be given as a list of strings, or just a string that separates multiple `host:port`
+      entries with `;` or a ` ` (space).
+    * `:reconnect_cool_down_seconds` – the number of seconds to wait between re-connection attempts (default: 10)
+    * `:auto_start_producers` – set to false if you want to manually start your `:brod_producer` (default: true)
+    * `:default_producer_config` – set default options to be passed to the start of producers (default: [])
+  """
+  @callback start_link(opts :: Keyword.t) :: {:ok, pid} |
+                            {:error, {:already_started, pid}} |
+                            {:error, term}
 end
+

--- a/lib/brod_ex/client.ex
+++ b/lib/brod_ex/client.ex
@@ -35,8 +35,6 @@ defmodule BrodEx.Client do
         clients = Application.get_env(:brod, :clients, [])
                   |> Keyword.merge([{__MODULE__, client_config}])
 
-        Application.put_env(:brod, :clients, clients)
-
         :brod.start_link_client(client_config[:endpoints], __MODULE__, client_config)
       end
 

--- a/lib/brod_ex/config.ex
+++ b/lib/brod_ex/config.ex
@@ -4,6 +4,15 @@ defmodule BrodEx.Config do
   @type endpoint :: {charlist, pos_integer} | {}
   @type endpoints :: [endpoint]
 
+  def brod_client_config(config) do
+    [
+      endpoints: Keyword.fetch!(config, :endpoints) |> parse_endpoints,
+      reconnect_cool_down_seconds: Keyword.get(config, :reconnect_cool_down_seconds, 10),
+      auto_start_producers: Keyword.get(config, :auto_start_producers, true),
+      default_producer_config: Keyword.get(config, :default_producer_config, [])
+    ]
+  end
+
   @type client_option :: {:endpoints, endpoints | String.t} |
                          {:reconnect_cool_down_seconds, integer} |
                          {:auto_start_producers, boolean} |

--- a/mix.exs
+++ b/mix.exs
@@ -17,28 +17,22 @@ defmodule BrodEx.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
-    # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger]]
+    [
+      extra_applications: [
+        :logger,
+        :brod
+      ]
+    ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:my_dep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
-    [{:brod, "~> 3.0.0", runtime: false},
-     {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
-     {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+    [
+      {:brod, "~> 3.0.0", runtime: false},
+      {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 
   defp package do

--- a/test/brod_ex_client_test.exs
+++ b/test/brod_ex_client_test.exs
@@ -2,14 +2,15 @@ defmodule Brodex.ClientTest do
   @moduledoc false
   use ExUnit.Case
 
-  Application.put_env(:test_app, :clients, [])
+  Application.put_env(:test_app, Brodex.ClientTest.TestApp.Brod, [endpoints: ["localhost:9092"]])
+
   defmodule TestApp.Brod do
     @moduledoc false
     use BrodEx, otp_app: :test_app
   end
 
   setup do
-    :ok = TestApp.Brod.start_link([])
+    {:ok, _pid} = TestApp.Brod.start_link()
 
     on_exit fn ->
       BrodEx.stop
@@ -20,5 +21,5 @@ defmodule Brodex.ClientTest do
     assert Application.started_applications |> List.keyfind(:brod, 0) != nil
   end
 
-  
+
 end


### PR DESCRIPTION
I really like that idea, similar to `Ecto.Repo` that you can have a module per kafka broker.
This PR makes this possible.

So the following things have changed:

* `BrodEx.Client` is now an actual `brod_client`.

    An user of this library can simply put it into his supervision tree, similar to starting an `Ecto.Repo`. The configuration still happens in `config/config.exs` but can be overwritten on `BrodEx.Client.start_link/1`.

* Added an `example/` directory, containing an actual example application using `BrodEx`.

    Go checkout `example/dev/kafka.yml` its a nice and tidy docker compose file to spin up a working Kafka version 1.1.0.
    I will use this example app to implement tests that revolve around integrating `BrodEx` into other applications. For example testing the integration of handler modules etc. That is what I am currently working on.

* Added `BrodEx.Client.produce_sync/4`

    This might feel unnecessary when having delegated such methods in the `BrodEx` module already. But hear me out, I want to make these clients the entry point for the user to interact with Kafka. And since `brod` has an awfully inaccessible documentation, I feel this is really helpful for getting the hex documentation right.

* Added `:brod` to the list of `:extra_applications`

    A user of this library should not have to deal with adding anything to his extra applications. I would expect this to work out-of-the-box™

* Started to write documentation for the `BrodEx.Client` behaviour